### PR TITLE
## 🐛 Problem The Auto Labeler GitHub Action was failing due to incorrect YAML syntax in `.github/labeler.yml`.  ##[GSSoC 2025]

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,7 +9,7 @@ enhancement:
 good first issue:
   - 'good first issue'
 GSSoC25:
-  - 'GSSoC\'25'
+  - "GSSoC'25"
 help wanted:
   - 'help wanted'
 invalid:


### PR DESCRIPTION
## 🐛 Problem
The Auto Labeler GitHub Action was failing due to incorrect YAML syntax in `.github/labeler.yml`.

## ✅ Solution  
Fixed the quote escaping for the `GSSoC'25` label by changing from single quotes with escape to double quotes.

## 🧪 Testing
- YAML syntax is now valid
- This should resolve the failing Auto Labeler check in PR #24

Fixes the failing checks in #24