### PR TITLE
Enhance: Add hover-expandable sidebar with fixed layout

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,7 +10,7 @@ export default function App() {
   return (
     <div className="min-h-screen bg-gray-100 flex">
       <Sidebar />
-      <main className="flex-1 p-10">
+      <main className="flex-1 p-10 ml-44 peer-hover:ml-64  transition-all h-screen duration-300">
         <Routes>
           <Route path="/" element={<Navigate to="/dashboard" replace />} />
           <Route path="/dashboard" element={<DashboardPage />} />

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,15 +1,16 @@
 import { NavLink } from "react-router-dom";
 
 const linkClass = ({ isActive }) =>
-  `block w-full text-left px-4 py-2 rounded-md hover:bg-gray-800 ${
+  `block w-full text-left px-4 py-2 transition-all duration-300 rounded-md hover:bg-gray-800 ${
     isActive ? "bg-gray-800" : ""
   }`;
 
 export default function Sidebar() {
   return (
-    <aside className="bg-gray-900 text-white w-64 min-h-screen p-6">
+    <aside className="peer fixed top-0 left-0 bg-gray-900 text-white min-h-screen p-6 transition-all duration-300 w-44 hover:w-64"
+    >
       <div className="text-2xl font-bold mb-6">Schedulr</div>
-      <nav className="flex flex-col gap-1">
+      <nav className="flex flex-col gap-2">
         <NavLink to="/dashboard" className={linkClass}>
           Dashboard
         </NavLink>


### PR DESCRIPTION

## Description
This PR  updated the following changes:
- Added hover-expandable sidebar with smooth transition.
- Kept sidebar **fixed** to prevent it from scrolling with the main content.
- Fixed scrollbar issue so only main content scrolls, not the sidebar.

Closes #41 

## Screenshots

| Before | After |
|--------|-------|
| <img width="600" height="700" alt="dashboard_" src="https://github.com/user-attachments/assets/4376db79-2aab-4294-966a-ae5ecf56692d" /> | <img width="600" height="881" alt="updated_dashboard" src="https://github.com/user-attachments/assets/a1348396-6042-4e9c-80a9-2df7d3df73ef" /> |


## How to Test
Steps to verify this change:
1. Open the site.
2. Hover over the sidebar area — it should expand.
3. Hover over the content area — sidebar should remain expanded.
4. Scroll main content — sidebar stays fixed.

## Additional contest
Kindly review this pull request and assign the label in it
