### PR TITLE
Chore: Install React Icons library

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^7.9.1",
         "swiper": "^12.0.2",
         "tailwindcss": "^4.1.13"
@@ -3358,6 +3359,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^7.9.1",
     "swiper": "^12.0.2",
     "tailwindcss": "^4.1.13"


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
This PR installs **React Icons** and updates the project to use them where applicable (e.g., sidebar icons).

closes #72 

## How to Test
Steps to verify this change:
1. Install dependencies: `npm install` or `yarn install`
2. Start the app: `npm run dev` 
3. No visible changes yet—this PR only installs the React Icons library.

## Additional context
Sidebar icons can be updated after this PR is merged, because it adds the React Icons library.
