### PR TITLE
Added 'Back to Login' link on signup page for better navigation

### DIFF
--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -76,6 +76,15 @@ export default function RegisterPage() {
   return (
     <div className="min-h-screen bg-gray-100 flex items-center justify-center">
       <div className="bg-white rounded-lg shadow-xl w-full max-w-md p-8">
+
+        {/* 🔹 Added "Back to Login" link at the top */}
+        <Link
+          to="/login"
+          className="inline-flex items-center text-blue-500 hover:text-blue-600 mb-4"
+        >
+          ← Back to Login
+        </Link>
+
         <div className="text-center mb-8">
           <h1 className="text-2xl sm:text-3xl font-bold text-gray-800 mb-2">Create Account</h1>
           <p className="text-gray-600">Sign up to get started</p>


### PR DESCRIPTION
### What’s changed:
- Added a simple "← Back to Login" link at the top of the Signup page.

### Why this change:
- Improves user navigation between Sign Up and Login pages.
- Provides a better user experience (UX) by allowing users to easily return to the login page.

### Testing:
- Verified locally that the link appears correctly above the signup form.
- Clicking the link navigates to the `/login` page as expected.

### Notes:
- This is a minor UX improvement and does not affect any existing functionality.
